### PR TITLE
Fix logic around message truncation

### DIFF
--- a/includes/twitter.class.php
+++ b/includes/twitter.class.php
@@ -44,9 +44,8 @@ class Twitter {
 		if ($this->testing) $limit -= 15;
 
 		if (strlen($message) > $limit) {
-			$words = str_word_count($message, 2);
-			$pos = array_keys($words);
-			$message = substr($message, 0, $pos[$limit]) . '...';
+			$message = wordwrap($message, $limit);
+			$message = substr($message, 0, strpos($message, "\n")) . '...';
 		}
 
 		if ($this->testing) echo "Final twitter message: {$message}\n";


### PR DESCRIPTION
In the old logic, if 137 did not appear in "$pos = array_keys($words);" it would fail completely and just put up "..." as the message.

Using the wordwrap function and taking only the first value ensures you always get a full word as close to the desired length as possible and reduces overal complexity.
