### PR TITLE
Fix "Object of class SQLite3Result could not be converted to int" within includes/database.class.php

### DIFF
--- a/includes/database.class.php
+++ b/includes/database.class.php
@@ -9,11 +9,26 @@ class Database {
 		$this->initialize();	
 	}
 
+	function _get_count_result($handle) {
+		$count = 0;
+		if (gettype($handle) == 'object') {
+                        $row = array();
+			$row = $handle->fetchArray();
+                        $count = $row['COUNT(*)'];
+                }
+                else {
+                        $count = $handle;
+                }
+
+		return $count;
+	}
+
 	function initialize() {
 		if (($this->sqlite = new SQLite3($this->dbpath)) === false) throw new Exception('Unable to save database file.');
 
 		$check_users = @$this->sqlite->query('SELECT COUNT(*) FROM users');
-		if ($check_users === false || $check_users < 1) {
+		$check_users_count = $this->_get_count_result($check_users);
+		if (!isset($check_users) || $check_users_count < 1) {
 			// Creating user table
 			echo "Creating user table...<br />\n";
 			$this->sqlite->query("CREATE TABLE users (id integer primary key autoincrement, username varchar unique, password varchar)");
@@ -25,7 +40,8 @@ class Database {
 		}
 
 		$check_facilities = @$this->sqlite->query('SELECT COUNT(*) FROM facilities');
-		if ($check_facilities === false || $check_facilities < 1) {
+		$check_facilities_count = $this->_get_count_result($check_facilities);
+		if ($check_facilities === false || $check_facilities_count < 1) {
 			// Creating facilities table
 			echo "Creating facilities table...<br />\n";
 			$this->sqlite->query("CREATE TABLE facilities (id integer primary key autoincrement, friendly_name varchar, visible int default 1)");
@@ -41,7 +57,8 @@ class Database {
 
 
 		$check_facilities_services = @$this->sqlite->query('SELECT COUNT(*) FROM facilities_services');
-		if ($check_facilities_services === false || $check_facilities_services < 1) {
+		$check_facilities_services_count = $this->_get_count_result($check_facilities_services);
+		if ($check_facilities_services === false || $check_facilities_services_count < 1) {
 			// Creating facilities_services table
 			echo "Creating facilities_services table...<br />\n";
 			$this->sqlite->query("CREATE TABLE facilities_services (id integer primary key autoincrement, facilities_id integer, friendly_name varchar, status varchar)");


### PR DESCRIPTION
Initial installations of statuspage on Ubuntu 12.04 with PHP 5.3.10 generate warnings such as:

```
PHP Notice:  Object of class SQLite3Result could not be converted to int in /var/www/example.com/includes/database.class.php on line 16
PHP Stack trace:
PHP   1. {main}() /var/www/example.com/public/index.php:0
PHP   2. include() /var/www/example.com/public/index.php:2
PHP   3. Database->__construct() /var/www/example.com/includes/base.inc.php:8
PHP   4. Database->initialize() /var/www/example.com/includes/database.class.php:9

PHP Notice:  Object of class SQLite3Result could not be converted to int in /var/www/example.com/includes/database.class.php on line 28
PHP Stack trace:
PHP   1. {main}() /var/www/example.com/public/index.php:0
PHP   2. include() /var/www/example.com/public/index.php:2
PHP   3. Database->__construct() /var/www/example.com/includes/base.inc.php:8
PHP   4. Database->initialize() /var/www/example.com/includes/database.class.php:9

PHP Notice:  Object of class SQLite3Result could not be converted to int in /var/www/example.com/includes/database.class.php on line 44
PHP Stack trace:
PHP   1. {main}() /var/www/example.com/public/index.php:0
PHP   2. include() /var/www/example.com/public/index.php:2
PHP   3. Database->__construct() /var/www/example.com/includes/base.inc.php:8
PHP   4. Database->initialize() /var/www/example.com/includes/database.class.php:9
```

database.class.php attempts to evaluate an SQLite3Result object numerically.

This patch addresses this issue, while utilising existing behaviour if the passed var isn't an object.
