### PR TITLE
Fix "Undefined index: smarty_debug" notices generated by includes/template.inc.php

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -25,4 +25,5 @@ $config['textarea'] = array(
 	'heading' => 'Get Support',
 	'text' => 'Having service issues? In the event that our ticketing system is offline we will monitor emails sent to <a href="mailto:support@example.com">support@example.com</a>. Please be advised that unless our ticketing system is inaccessable this mail box is not actively monitored and you should <a href="https://example.com/support/newticket.html" target="_blank">open a ticket</a> for support.'
 );
+$config['smarty_debug'] = false;
 ?>


### PR DESCRIPTION
The default includes/config.php omits specifying $config['smarty_debug'] this results in PHP notices such as:

```
PHP Notice:  Undefined index: smarty_debug in /var/www/example.com/includes/template.inc.php on line 15
PHP Stack trace:
PHP   1. {main}() /var/www/example.com/public/login.php:0
PHP   2. include() /var/www/example.com/public/login.php:2
PHP   3. require_once() /var/www/example.com/includes/base.inc.php:11
```

for every request.  This trivial patch includes a sensible default and prevents this notices.
